### PR TITLE
Fix: Remove unused local variable

### DIFF
--- a/test/Unit/ProductionTest.php
+++ b/test/Unit/ProductionTest.php
@@ -160,8 +160,6 @@ final class ProductionTest extends Framework\TestCase
      */
     public function testUnsetThrowsInvalidNameWhenNameIsInvalid(string $name): void
     {
-        $value = self::faker()->sentence;
-
         $variables = new Production();
 
         $this->expectException(Exception\InvalidName::class);


### PR DESCRIPTION
This PR

* [x] removes an unused local variable