### PR TITLE
restore 100% type coverage

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -4,19 +4,6 @@
     <DocblockTypeContradiction occurrences="1">
       <code>\is_string($name)</code>
     </DocblockTypeContradiction>
-    <MissingPropertyType occurrences="1">
-      <code>$values</code>
-    </MissingPropertyType>
-    <MixedArgument occurrences="2">
-      <code>$this-&gt;values</code>
-      <code>$this-&gt;values</code>
-    </MixedArgument>
-    <MixedArrayAccess occurrences="1">
-      <code>$this-&gt;values[$name]</code>
-    </MixedArrayAccess>
-    <MixedInferredReturnType occurrences="1">
-      <code>get</code>
-    </MixedInferredReturnType>
     <RedundantConditionGivenDocblockType occurrences="1">
       <code>!\is_string($name) || '' === $name</code>
     </RedundantConditionGivenDocblockType>
@@ -25,16 +12,6 @@
     <DocblockTypeContradiction occurrences="1">
       <code>\is_string($name)</code>
     </DocblockTypeContradiction>
-    <MissingPropertyType occurrences="1">
-      <code>$values</code>
-    </MissingPropertyType>
-    <MixedArgument occurrences="2">
-      <code>$this-&gt;values</code>
-      <code>$this-&gt;values</code>
-    </MixedArgument>
-    <MixedInferredReturnType occurrences="1">
-      <code>get</code>
-    </MixedInferredReturnType>
     <RedundantConditionGivenDocblockType occurrences="1">
       <code>!\is_string($name) || '' === $name</code>
     </RedundantConditionGivenDocblockType>

--- a/psalm.xml
+++ b/psalm.xml
@@ -7,11 +7,8 @@
     errorBaseline="psalm-baseline.xml"
     errorLevel="1"
     resolveFromConfigFile="true"
+    totallyTyped="true"
 >
-    <issueHandlers>
-        <LessSpecificReturnType errorLevel="info" />
-    </issueHandlers>
-
     <plugins>
         <pluginClass class="Psalm\PhpUnitPlugin\Plugin" />
     </plugins>

--- a/src/FakeVariables.php
+++ b/src/FakeVariables.php
@@ -15,6 +15,7 @@ namespace Ergebnis\Environment;
 
 final class FakeVariables implements Variables
 {
+    /** @var array<string> */
     private $values = [];
 
     /**

--- a/src/ReadOnlyVariables.php
+++ b/src/ReadOnlyVariables.php
@@ -15,6 +15,7 @@ namespace Ergebnis\Environment;
 
 final class ReadOnlyVariables implements Variables
 {
+    /** @var array<string> */
     private $values = [];
 
     /**


### PR DESCRIPTION
This PR

* [x] Restores 100% type coverage
* [x] Enable totallyTyped=true in Psalm for better visibility of mixed Issues
* [x] Updates baseline
* [x] Deletes the LessSpecificReturnType issueHandler that wasn't doing anything

I saw your type coverage lower on shepherd.dev :)
