### PR TITLE
Enhancement: Throw exception when environment variable could not be set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ For a full diff see [`c0c63bb...master`][c0c63bb...master].
 * Renamed namespace `Ergebnis\Environment\Variables` to `Ergebnis\Environment` ([#5]), by [@localheinz]
 * Renamed `Ergebnis\Environment\Production` to `Ergebnis\Environment\SystemVariables` ([#6]), by [@localheinz]
 * Renamed `Ergebnis\Environment\Test` to `Ergebnis\Environment\TestVariables` ([#9]), by [@localheinz]
+* Started throwing `Ergebnis\Environment\Exception\CouldNotSet` when a system environment variable could not be set ([#14]), by [@localheinz]
 
 [c0c63bb...master]: https://github.com/ergebnis/environment-variables/compare/c0c63bb...master
 
@@ -30,5 +31,6 @@ For a full diff see [`c0c63bb...master`][c0c63bb...master].
 [#7]: https://github.com/ergebnis/environment-variables/pull/7
 [#8]: https://github.com/ergebnis/environment-variables/pull/8
 [#9]: https://github.com/ergebnis/environment-variables/pull/9
+[#14]: https://github.com/ergebnis/environment-variables/pull/14
 
 [@localheinz]: https://github.com/localheinz

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -7,6 +7,7 @@ parameters:
 		classesAllowedToBeExtended:
 			- BadMethodCallException
 			- InvalidArgumentException
+			- RuntimeException
 	inferPrivatePropertyTypeFromConstructor: true
 	level: max
 	paths:

--- a/src/Exception/CouldNotSet.php
+++ b/src/Exception/CouldNotSet.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2020 Andreas Möller
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE.md file that was distributed with this source code.
+ *
+ * @see https://github.com/ergebnis/environment-variables
+ */
+
+namespace Ergebnis\Environment\Exception;
+
+final class CouldNotSet extends \RuntimeException implements Exception
+{
+    public static function name(string $name): self
+    {
+        return new self(\sprintf(
+            'Could not set environment variable "%s".',
+            $name
+        ));
+    }
+}

--- a/src/SystemVariables.php
+++ b/src/SystemVariables.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace Ergebnis\Environment;
 
+use Ergebnis\Environment\Exception\CouldNotSet;
+
 final class SystemVariables implements Variables
 {
     public function has(string $name): bool
@@ -39,11 +41,15 @@ final class SystemVariables implements Variables
             throw Exception\InvalidName::create();
         }
 
-        \putenv(\sprintf(
+        $hasBeenSet = \putenv(\sprintf(
             '%s=%s',
             $name,
             $value
         ));
+
+        if (false === $hasBeenSet) {
+            throw CouldNotSet::name($name);
+        }
     }
 
     public function unset(string $name): void

--- a/src/Variables.php
+++ b/src/Variables.php
@@ -37,6 +37,7 @@ interface Variables
      * @param string $name
      * @param string $value
      *
+     * @throws Exception\CouldNotSet
      * @throws Exception\InvalidName
      */
     public function set(string $name, string $value): void;

--- a/test/Unit/Exception/CouldNotSetTest.php
+++ b/test/Unit/Exception/CouldNotSetTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2020 Andreas Möller
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE.md file that was distributed with this source code.
+ *
+ * @see https://github.com/ergebnis/environment-variables
+ */
+
+namespace Ergebnis\Environment\Test\Unit\Exception;
+
+use Ergebnis\Environment\Exception\CouldNotSet;
+use Ergebnis\Test\Util\Helper;
+use PHPUnit\Framework;
+
+/**
+ * @internal
+ *
+ * @covers \Ergebnis\Environment\Exception\CouldNotSet
+ */
+final class CouldNotSetTest extends Framework\TestCase
+{
+    use Helper;
+
+    public function testNameReturnsException(): void
+    {
+        $name = self::faker()->word;
+
+        $exception = CouldNotSet::name($name);
+
+        $message = \sprintf(
+            'Could not set environment variable "%s".',
+            $name
+        );
+
+        self::assertSame($message, $exception->getMessage());
+    }
+}


### PR DESCRIPTION
This PR

* [x] throws an exception when a system environment variable could not be set