### PR TITLE
Enhancement: Throw exception when environment variable could not be unset

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -9,8 +9,8 @@ on:
       - "master"
 
 env:
-  MIN_COVERED_MSI: 97
-  MIN_MSI: 97
+  MIN_COVERED_MSI: 96
+  MIN_MSI: 96
   REQUIRED_PHP_EXTENSIONS: "mbstring"
 
 jobs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ For a full diff see [`c0c63bb...master`][c0c63bb...master].
 * Renamed `Ergebnis\Environment\Production` to `Ergebnis\Environment\SystemVariables` ([#6]), by [@localheinz]
 * Renamed `Ergebnis\Environment\Test` to `Ergebnis\Environment\TestVariables` ([#9]), by [@localheinz]
 * Started throwing `Ergebnis\Environment\Exception\CouldNotSet` when a system environment variable could not be set ([#14]), by [@localheinz]
+* Started throwing `Ergebnis\Environment\Exception\CouldNotUnset` when a system environment variable could not be unset ([#15]), by [@localheinz]
 
 [c0c63bb...master]: https://github.com/ergebnis/environment-variables/compare/c0c63bb...master
 
@@ -32,5 +33,6 @@ For a full diff see [`c0c63bb...master`][c0c63bb...master].
 [#8]: https://github.com/ergebnis/environment-variables/pull/8
 [#9]: https://github.com/ergebnis/environment-variables/pull/9
 [#14]: https://github.com/ergebnis/environment-variables/pull/14
+[#15]: https://github.com/ergebnis/environment-variables/pull/15
 
 [@localheinz]: https://github.com/localheinz

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
-MIN_COVERED_MSI:=97
-MIN_MSI:=97
+MIN_COVERED_MSI:=96
+MIN_MSI:=96
 
 .PHONY: it
 it: coding-standards dependency-analysis static-code-analysis tests ## Runs the coding-standards, dependency-analysis, static-code-analysis, and tests targets

--- a/src/Exception/CouldNotUnset.php
+++ b/src/Exception/CouldNotUnset.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2020 Andreas Möller
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE.md file that was distributed with this source code.
+ *
+ * @see https://github.com/ergebnis/environment-variables
+ */
+
+namespace Ergebnis\Environment\Exception;
+
+final class CouldNotUnset extends \RuntimeException implements Exception
+{
+    public static function name(string $name): self
+    {
+        return new self(\sprintf(
+            'Could not unset environment variable "%s".',
+            $name
+        ));
+    }
+}

--- a/src/SystemVariables.php
+++ b/src/SystemVariables.php
@@ -13,8 +13,6 @@ declare(strict_types=1);
 
 namespace Ergebnis\Environment;
 
-use Ergebnis\Environment\Exception\CouldNotSet;
-
 final class SystemVariables implements Variables
 {
     public function has(string $name): bool
@@ -48,7 +46,7 @@ final class SystemVariables implements Variables
         ));
 
         if (false === $hasBeenSet) {
-            throw CouldNotSet::name($name);
+            throw Exception\CouldNotSet::name($name);
         }
     }
 
@@ -58,6 +56,10 @@ final class SystemVariables implements Variables
             throw Exception\InvalidName::create();
         }
 
-        \putenv($name);
+        $hasBeenUnset = \putenv($name);
+
+        if (false === $hasBeenUnset) {
+            throw Exception\CouldNotUnset::name($name);
+        }
     }
 }

--- a/test/Unit/Exception/CouldNotUnsetTest.php
+++ b/test/Unit/Exception/CouldNotUnsetTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2020 Andreas Möller
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE.md file that was distributed with this source code.
+ *
+ * @see https://github.com/ergebnis/environment-variables
+ */
+
+namespace Ergebnis\Environment\Test\Unit\Exception;
+
+use Ergebnis\Environment\Exception\CouldNotUnset;
+use Ergebnis\Test\Util\Helper;
+use PHPUnit\Framework;
+
+/**
+ * @internal
+ *
+ * @covers \Ergebnis\Environment\Exception\CouldNotUnset
+ */
+final class CouldNotUnsetTest extends Framework\TestCase
+{
+    use Helper;
+
+    public function testNameReturnsException(): void
+    {
+        $name = self::faker()->word;
+
+        $exception = CouldNotUnset::name($name);
+
+        $message = \sprintf(
+            'Could not unset environment variable "%s".',
+            $name
+        );
+
+        self::assertSame($message, $exception->getMessage());
+    }
+}


### PR DESCRIPTION
This PR

* [x] throws an exception when a system environment variable could not be unset