### PR TITLE
Enhancement: Throw exception when retrieving value of variable that is not set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ For a full diff see [`c0c63bb...master`][c0c63bb...master].
 * Renamed `Ergebnis\Environment\Test` to `Ergebnis\Environment\TestVariables` ([#9]), by [@localheinz]
 * Started throwing `Ergebnis\Environment\Exception\CouldNotSet` when a system environment variable could not be set ([#14]), by [@localheinz]
 * Started throwing `Ergebnis\Environment\Exception\CouldNotUnset` when a system environment variable could not be unset ([#15]), by [@localheinz]
+* Started throwing `Ergebnis\Environment\Exception\NotSet` when attempting to retrieve the value of an environment variable that is not set ([#16]), by [@localheinz]
 
 [c0c63bb...master]: https://github.com/ergebnis/environment-variables/compare/c0c63bb...master
 
@@ -34,5 +35,6 @@ For a full diff see [`c0c63bb...master`][c0c63bb...master].
 [#9]: https://github.com/ergebnis/environment-variables/pull/9
 [#14]: https://github.com/ergebnis/environment-variables/pull/14
 [#15]: https://github.com/ergebnis/environment-variables/pull/15
+[#16]: https://github.com/ergebnis/environment-variables/pull/16
 
 [@localheinz]: https://github.com/localheinz

--- a/src/Exception/NotSet.php
+++ b/src/Exception/NotSet.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2020 Andreas Möller
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE.md file that was distributed with this source code.
+ *
+ * @see https://github.com/ergebnis/environment-variables
+ */
+
+namespace Ergebnis\Environment\Exception;
+
+final class NotSet extends \InvalidArgumentException implements Exception
+{
+    public static function name(string $name): self
+    {
+        return new self(\sprintf(
+            'The environment variable "%s" is not set.',
+            $name
+        ));
+    }
+}

--- a/src/FakeVariables.php
+++ b/src/FakeVariables.php
@@ -58,14 +58,14 @@ final class FakeVariables implements Variables
         return \array_key_exists($name, $this->values);
     }
 
-    public function get(string $name)
+    public function get(string $name): string
     {
         if ('' === $name || \trim($name) !== $name) {
             throw Exception\InvalidName::create();
         }
 
         if (!\array_key_exists($name, $this->values)) {
-            return false;
+            throw Exception\NotSet::name($name);
         }
 
         return $this->values[$name];

--- a/src/ReadOnlyVariables.php
+++ b/src/ReadOnlyVariables.php
@@ -15,6 +15,9 @@ namespace Ergebnis\Environment;
 
 final class ReadOnlyVariables implements Variables
 {
+    /**
+     * @var array<string, string>
+     */
     private $values = [];
 
     /**
@@ -55,14 +58,14 @@ final class ReadOnlyVariables implements Variables
         return \array_key_exists($name, $this->values);
     }
 
-    public function get(string $name)
+    public function get(string $name): string
     {
         if ('' === $name || \trim($name) !== $name) {
             throw Exception\InvalidName::create();
         }
 
         if (!\array_key_exists($name, $this->values)) {
-            return false;
+            throw Exception\NotSet::name($name);
         }
 
         return $this->values[$name];

--- a/src/SystemVariables.php
+++ b/src/SystemVariables.php
@@ -24,13 +24,19 @@ final class SystemVariables implements Variables
         return false !== \getenv($name);
     }
 
-    public function get(string $name)
+    public function get(string $name): string
     {
         if ('' === $name || \trim($name) !== $name) {
             throw Exception\InvalidName::create();
         }
 
-        return \getenv($name);
+        $value = \getenv($name);
+
+        if (!\is_string($value)) {
+            throw Exception\NotSet::name($name);
+        }
+
+        return $value;
     }
 
     public function set(string $name, string $value): void

--- a/src/Variables.php
+++ b/src/Variables.php
@@ -29,9 +29,9 @@ interface Variables
      *
      * @throws Exception\InvalidName
      *
-     * @return bool|string
+     * @return string
      */
-    public function get(string $name);
+    public function get(string $name): string;
 
     /**
      * @param string $name

--- a/test/Unit/Exception/NotSetTest.php
+++ b/test/Unit/Exception/NotSetTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2020 Andreas Möller
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE.md file that was distributed with this source code.
+ *
+ * @see https://github.com/ergebnis/environment-variables
+ */
+
+namespace Ergebnis\Environment\Test\Unit\Exception;
+
+use Ergebnis\Environment\Exception\NotSet;
+use Ergebnis\Test\Util\Helper;
+use PHPUnit\Framework;
+
+/**
+ * @internal
+ *
+ * @covers \Ergebnis\Environment\Exception\NotSet
+ */
+final class NotSetTest extends Framework\TestCase
+{
+    use Helper;
+
+    public function testNameReturnsException(): void
+    {
+        $name = self::faker()->word;
+
+        $exception = NotSet::name($name);
+
+        $message = \sprintf(
+            'The environment variable "%s" is not set.',
+            $name
+        );
+
+        self::assertSame($message, $exception->getMessage());
+    }
+}

--- a/test/Unit/FakeVariablesTest.php
+++ b/test/Unit/FakeVariablesTest.php
@@ -25,6 +25,7 @@ use PHPUnit\Framework;
  *
  * @uses \Ergebnis\Environment\Exception\InvalidName
  * @uses \Ergebnis\Environment\Exception\InvalidValue
+ * @uses \Ergebnis\Environment\Exception\NotSet
  * @uses \Ergebnis\Environment\TestVariables
  */
 final class FakeVariablesTest extends Framework\TestCase
@@ -118,20 +119,24 @@ final class FakeVariablesTest extends Framework\TestCase
         $variables->get($name);
     }
 
-    public function testGetReturnsFalseWhenEnvironmentVariableHasNotBeenInjected(): void
+    public function testGetThrowsNotSetWhenEnvironmentVariableHasNotBeenInjected(): void
     {
         $variables = new FakeVariables();
 
-        self::assertFalse($variables->get(self::NAME));
+        $this->expectException(Exception\NotSet::class);
+
+        $variables->get(self::NAME);
     }
 
-    public function testGetReturnsFalseWhenEnvironmentVariableHasBeenInjectedButValueIsFalse(): void
+    public function testGetThrowsNotSetWhenEnvironmentVariableHasBeenInjectedButValueIsFalse(): void
     {
         $variables = new FakeVariables([
             self::NAME => false,
         ]);
 
-        self::assertFalse($variables->get(self::NAME));
+        $this->expectException(Exception\NotSet::class);
+
+        $variables->get(self::NAME);
     }
 
     public function testGetReturnsValueWhenEnvironmentVariableHasBeenInjectedAndValueIsNotFalse(): void
@@ -202,6 +207,6 @@ final class FakeVariablesTest extends Framework\TestCase
 
         $variables->unset(self::NAME);
 
-        self::assertFalse($variables->get(self::NAME));
+        self::assertFalse($variables->has(self::NAME));
     }
 }

--- a/test/Unit/ReadOnlyVariablesTest.php
+++ b/test/Unit/ReadOnlyVariablesTest.php
@@ -25,6 +25,7 @@ use PHPUnit\Framework;
  *
  * @uses \Ergebnis\Environment\Exception\InvalidName
  * @uses \Ergebnis\Environment\Exception\InvalidValue
+ * @uses \Ergebnis\Environment\Exception\NotSet
  * @uses \Ergebnis\Environment\Exception\ShouldNotBeUsed
  * @uses \Ergebnis\Environment\TestVariables
  */
@@ -119,20 +120,24 @@ final class ReadOnlyVariablesTest extends Framework\TestCase
         $variables->get($name);
     }
 
-    public function testGetReturnsFalseWhenEnvironmentVariableHasNotBeenInjected(): void
+    public function testGetThrowsNotSetWhenEnvironmentVariableHasNotBeenInjected(): void
     {
         $variables = new ReadOnlyVariables();
 
-        self::assertFalse($variables->get(self::NAME));
+        $this->expectException(Exception\NotSet::class);
+
+        $variables->get(self::NAME);
     }
 
-    public function testGetReturnsFalseWhenEnvironmentVariableHasBeenInjectedButValueIsFalse(): void
+    public function testGetThrowsNotSetWhenEnvironmentVariableHasBeenInjectedButValueIsFalse(): void
     {
         $variables = new ReadOnlyVariables([
             self::NAME => false,
         ]);
 
-        self::assertFalse($variables->get(self::NAME));
+        $this->expectException(Exception\NotSet::class);
+
+        $variables->get(self::NAME);
     }
 
     public function testGetReturnsValueWhenEnvironmentVariableHasBeenInjectedAndValueIsNotFalse(): void

--- a/test/Unit/SystemVariablesTest.php
+++ b/test/Unit/SystemVariablesTest.php
@@ -25,6 +25,7 @@ use PHPUnit\Framework;
  * @covers \Ergebnis\Environment\SystemVariables
  *
  * @uses \Ergebnis\Environment\Exception\InvalidName
+ * @uses \Ergebnis\Environment\Exception\NotSet
  * @uses \Ergebnis\Environment\TestVariables
  */
 final class SystemVariablesTest extends Framework\TestCase
@@ -98,11 +99,13 @@ final class SystemVariablesTest extends Framework\TestCase
         $variables->get($name);
     }
 
-    public function testGetReturnsFalseWhenEnvironmentVariableIsNotSet(): void
+    public function testGetThrowsNotSetFalseWhenEnvironmentVariableIsNotSet(): void
     {
         $variables = new SystemVariables();
 
-        self::assertFalse($variables->get(self::NAME));
+        $this->expectException(Exception\NotSet::class);
+
+        $variables->get(self::NAME);
     }
 
     public function testGetReturnsValueWhenEnvironmentVariableIsSet(): void


### PR DESCRIPTION
This PR

* [x] throws an exception when retrieving value of environment variable that is not set

💁‍♂ It introduces temporal coupling, but gives us type-safety.