### PR TITLE
Enhancement: Use `AbstractProvider`

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="4.9.2@00c062267d6e3229d91a1939992987e2d46f2393">
+<files psalm-version="4.13.1@5cf660f63b548ccd4a56f62d916ee4d6028e01a3">
   <file src="src/FakeVariables.php">
     <DocblockTypeContradiction occurrences="2">
       <code>!\is_string($name)</code>
@@ -16,6 +16,18 @@
     <UnnecessaryVarAnnotation occurrences="1">
       <code>array&lt;string, string&gt;</code>
     </UnnecessaryVarAnnotation>
+  </file>
+  <file src="test/DataProvider/Name.php">
+    <MixedReturnTypeCoercion occurrences="4">
+      <code>\Generator&lt;string, array&lt;int&gt;&gt;</code>
+      <code>\Generator&lt;string, array&lt;string&gt;&gt;</code>
+    </MixedReturnTypeCoercion>
+  </file>
+  <file src="test/DataProvider/Value.php">
+    <MixedReturnTypeCoercion occurrences="4">
+      <code>\Generator&lt;string, array&lt;int, null|array|float|int|resource|\stdClass|true&gt;&gt;</code>
+      <code>\Generator&lt;string, array&lt;null|int|object|true&gt;&gt;</code>
+    </MixedReturnTypeCoercion>
   </file>
   <file src="test/Unit/FakeVariablesTest.php">
     <MixedArgumentTypeCoercion occurrences="2"/>

--- a/test/DataProvider/Name.php
+++ b/test/DataProvider/Name.php
@@ -13,12 +13,10 @@ declare(strict_types=1);
 
 namespace Ergebnis\Environment\Test\DataProvider;
 
-use Ergebnis\Environment\Test;
+use Ergebnis\DataProvider;
 
-final class Name
+final class Name extends DataProvider\AbstractProvider
 {
-    use Test\Util\Helper;
-
     /**
      * @return \Generator<string, array<int>>
      */
@@ -26,19 +24,13 @@ final class Name
     {
         $faker = self::faker();
 
-        $values = [
+        return self::provideDataForValues([
             'int-greater-than-one' => $faker->numberBetween(2),
             'int-less-than-minus-one' => -1 * $faker->numberBetween(2),
             'int-minus-one' => -1,
             'int-one' => 1,
             'int-zero' => 0,
-        ];
-
-        foreach ($values as $key => $value) {
-            yield $key => [
-                $value,
-            ];
-        }
+        ]);
     }
 
     /**
@@ -46,19 +38,13 @@ final class Name
      */
     public static function invalidValue(): \Generator
     {
-        $values = [
+        return self::provideDataForValues([
             'string-blank' => ' ',
             'string-empty' => '',
             'string-untrimmed' => \sprintf(
                 ' %s ',
                 self::faker()->sentence,
             ),
-        ];
-
-        foreach ($values as $key => $value) {
-            yield $key => [
-                $value,
-            ];
-        }
+        ]);
     }
 }

--- a/test/DataProvider/Value.php
+++ b/test/DataProvider/Value.php
@@ -13,12 +13,10 @@ declare(strict_types=1);
 
 namespace Ergebnis\Environment\Test\DataProvider;
 
-use Ergebnis\Environment\Test;
+use Ergebnis\DataProvider;
 
-final class Value
+final class Value extends DataProvider\AbstractProvider
 {
-    use Test\Util\Helper;
-
     /**
      * @return \Generator<string, array<int, null|array|float|int|resource|\stdClass|true>>
      */
@@ -29,7 +27,7 @@ final class Value
         /** @var resource $resource */
         $resource = \fopen(__FILE__, 'rb');
 
-        $values = [
+        return self::provideDataForValues([
             'array' => [
                 $faker->word,
                 $faker->word,
@@ -40,13 +38,7 @@ final class Value
             'null' => null,
             'object' => new \stdClass(),
             'resource' => $resource,
-        ];
-
-        foreach ($values as $key => $value) {
-            yield $key => [
-                $value,
-            ];
-        }
+        ]);
     }
 
     /**
@@ -54,14 +46,8 @@ final class Value
      */
     public static function invalidValue(): \Generator
     {
-        $values = [
+        return self::provideDataForValues([
             'bool-true' => true,
-        ];
-
-        foreach ($values as $key => $value) {
-            yield $key => [
-                $value,
-            ];
-        }
+        ]);
     }
 }


### PR DESCRIPTION
This pull request

* [x] uses the `AbstractProvider` as provided by `ergebnis/data-provider`